### PR TITLE
Handle invalid XML gracefully

### DIFF
--- a/Encoder/XmlEncoder.php
+++ b/Encoder/XmlEncoder.php
@@ -54,7 +54,10 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      */
     public function decode($data, $format)
     {
-        $xml = simplexml_load_string($data);
+        $xml = @simplexml_load_string($data);
+		if ($xml === false) {
+			return null;
+		}
         if (!$xml->count()) {
             if (!$xml->attributes()) {
                 return (string) $xml;


### PR DESCRIPTION
Simply avoids a PHP fatal error when trying to decode invalid XML.
