### PR TITLE
updated for 2.8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/property-access": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/cache": "~3.1",
-        "symfony/property-info": "~3.1",
+        "symfony/property-info": "~2.8|~3.1",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0",
         "phpdocumentor/reflection-docblock": "~3.0"


### PR DESCRIPTION
The `symfony/property-access` and `symfony/http-foundation` dependencies also allow 2.8 as option however the `symfony/property-info` dependency only allows 3.1. 

There is no point in property-access and http-foundation to allow 2.8 if any other dependency does not.  This is kind of also required for an upsteam fix into another project but I'm not sure that matters.

Setting the property-info dependency to allow 2.8 like the others. 