### PR TITLE
Added missing $context argument

### DIFF
--- a/Normalizer/DenormalizerInterface.php
+++ b/Normalizer/DenormalizerInterface.php
@@ -47,9 +47,10 @@ interface DenormalizerInterface
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.
      *
-     * @param mixed  $data   Data to denormalize from
-     * @param string $type   The class to which the data should be denormalized
-     * @param string $format The format being deserialized from
+     * @param mixed  $data    Data to denormalize from
+     * @param string $type    The class to which the data should be denormalized
+     * @param string $format  The format being deserialized from
+     * @param array  $context Options available to the denormalizer
      *
      * @return bool
      */

--- a/Normalizer/DenormalizerInterface.php
+++ b/Normalizer/DenormalizerInterface.php
@@ -53,5 +53,5 @@ interface DenormalizerInterface
      *
      * @return bool
      */
-    public function supportsDenormalization($data, $type, $format = null);
+    public function supportsDenormalization($data, $type, $format = null, $context = array());
 }


### PR DESCRIPTION
Optional $context argument should be included as in Serializer::getDenormalizer() the context is provided.