### PR TITLE
Date time Denormaliser - Manage Timezone in Constructor

### DIFF
--- a/Normalizer/DateTimeNormalizer.php
+++ b/Normalizer/DateTimeNormalizer.php
@@ -116,36 +116,21 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
         }
 
         try {
-            return $this->correctTimezone(\DateTime::class === $class ? new \DateTime($data, $timezone) : new \DateTimeImmutable($data, $timezone), $timezone);
+            $datetime = new \DateTime($data, $timezone);
+            /**
+             * PHP docs say when created a new DateTime object:
+             *
+             * The $timezone parameter and the current timezone are ignored when the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00).
+             *
+             * This means the behaviour in this normalizer is different when the timezone is applied in the constructor or later with setTimezone.
+             *
+             * If you specify the timezone when denormalizing, you'd expect all datetimes to come out in that timezone, regardless of (user) input.
+             */
+            $datetime->setTimezone($timezone);
+            return \DateTime::class === $class ? $datetime : new \DateTimeImmutable($datetime->format(\DATE_RFC3339), $timezone);
         } catch (\Exception $e) {
             throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
         }
-    }
-
-    /**
-     * correctTimeZone
-     * PHP docs say when created a new DateTime object:
-     *
-     * The $timezone parameter and the current timezone are ignored when the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00).
-     *
-     * This means the behaviour in this normalizer is different when the timezone is applied in the constructor or later with setTimezone.
-     *
-     * If you specify the timezone when denormalizing, you'd expect all datetimes to come out in that timezone, regardless of (user) input.
-     *
-     * @param \DateTimeInterface $datetime
-     * @param \DateTimeZone $timezone
-     * @return \DateTime|\DateTimeImmutable|\DateTimeInterface
-     * @throws \Exception
-     */
-    private function correctTimeZone(\DateTimeInterface $datetime, \DateTimeZone $timezone)
-    {
-        $immutable = false;
-        if ($datetime instanceof \DateTimeImmutable) {
-            $datetime = new \DateTime($datetime->format(\DATE_RFC3339), $timezone);
-            $immutable = true;
-        }
-        $datetime->setTimezone($timezone);
-        return $immutable ? new \DateTimeImmutable($datetime->format(\DATE_RFC3339), $timezone) : $datetime ;
     }
 
     /**

--- a/Tests/Normalizer/DateTimeNormalizerTest.php
+++ b/Tests/Normalizer/DateTimeNormalizerTest.php
@@ -206,6 +206,19 @@ class DateTimeNormalizerTest extends TestCase
     public function testDenormalizeUsingTimezonePassedInConstructor()
     {
         $this->doTestDenormalizeUsingTimezonePassedInConstructor();
+        // Test correction of Timezone when timezone information is added in both the date string and the context of the normalizer.
+        $normalizer = new DateTimeNormalizer(
+            [
+                // This is different from Europe times and has NO daylight saving, so tests always pass.
+                DateTimeNormalizer::TIMEZONE_KEY => 'Australia/Brisbane',
+            ]
+        );
+
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-27T16:39:26+01:00', \DateTimeInterface::class)->format(\DATE_RFC3339));
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-27T15:39:26+00:00', \DateTime::class)->format(\DATE_RFC3339));
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-28 01:39:26', \DateTime::class)->format(\DATE_RFC3339));
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('2016-01-28T01:39:26+10:00', \DateTimeInterface::class)->format(\DATE_RFC3339));
+        $this->assertEquals('2016-01-28T01:39:26+10:00', $normalizer->denormalize('@1453909166', \DateTimeImmutable::class)->format(\DATE_RFC3339));
     }
 
     public function testLegacyDenormalizeUsingTimezonePassedInConstructor()
@@ -222,6 +235,7 @@ class DateTimeNormalizerTest extends TestCase
         $this->assertEquals($expected, $normalizer->denormalize('2016.12.01 17:35:00', \DateTime::class, null, [
             DateTimeNormalizer::FORMAT_KEY => 'Y.m.d H:i:s',
         ]));
+
     }
 
     public function testDenormalizeUsingFormatPassedInContext()


### PR DESCRIPTION
Added code to enforce correct timestamp as defined in constructor for denormalisation function.  

__Description__

[PHP docs](https://www.php.net/manual/en/datetime.construct.php) say:

> The $timezone parameter and the current timezone are ignored when the $time parameter either is a UNIX timestamp (e.g. @946684800) or specifies a timezone (e.g. 2010-01-28T15:00:00+02:00).

This means the behaviour is different when the timezone is applied in the constructor or later with setTimezone.

This PR corrects the issue and adds a series of tests in DateTimeNormalizerTest::testDenormalizeUsingTimezonePassedInConstructor.  
