### PR TITLE
`str_contains` is only available from PHP 8.0

### DIFF
--- a/Normalizer/AbstractObjectNormalizer.php
+++ b/Normalizer/AbstractObjectNormalizer.php
@@ -472,7 +472,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // PHP's json_decode automatically converts Numbers without a decimal part to integers.
             // To circumvent this behavior, integers are converted to floats when denormalizing JSON based formats and when
             // a float is expected.
-            if (Type::BUILTIN_TYPE_FLOAT === $builtinType && \is_int($data) && str_contains($format, JsonEncoder::FORMAT)) {
+            if (Type::BUILTIN_TYPE_FLOAT === $builtinType && \is_int($data) && false !== strpos($format, JsonEncoder::FORMAT)) {
                 return (float) $data;
             }
 


### PR DESCRIPTION
`str_contains` is only available from PHP 8.0, since this version requires `>=7.1.3` this function will fail on older PHP versions.

So reverted it back to the `strpos()` method