### PR TITLE
`str_contains` and `str_starts_with` are only available from PHP 8.0

### DIFF
--- a/Encoder/CsvEncoder.php
+++ b/Encoder/CsvEncoder.php
@@ -149,7 +149,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         fwrite($handle, $data);
         rewind($handle);
 
-        if (str_starts_with($data, self::UTF8_BOM)) {
+        if (0 === strpos($data, self::UTF8_BOM)) {
             fseek($handle, \strlen(self::UTF8_BOM));
         }
 

--- a/Encoder/XmlEncoder.php
+++ b/Encoder/XmlEncoder.php
@@ -287,7 +287,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     final protected function isElementNameValid(string $name): bool
     {
         return $name &&
-            !str_contains($name, ' ') &&
+            false === strpos($name, ' ') &&
             preg_match('#^[\pL_][\pL0-9._:-]*$#ui', $name);
     }
 
@@ -413,7 +413,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         if (\is_array($data) || ($data instanceof \Traversable && (null === $this->serializer || !$this->serializer->supportsNormalization($data, $format)))) {
             foreach ($data as $key => $data) {
                 //Ah this is the magic @ attribute types.
-                if (str_starts_with($key, '@') && $this->isElementNameValid($attributeName = substr($key, 1))) {
+                if (0 === strpos($key, '@') && $this->isElementNameValid($attributeName = substr($key, 1))) {
                     if (!is_scalar($data)) {
                         $data = $this->serializer->normalize($data, $format, $context);
                     }

--- a/Normalizer/AbstractObjectNormalizer.php
+++ b/Normalizer/AbstractObjectNormalizer.php
@@ -472,7 +472,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // PHP's json_decode automatically converts Numbers without a decimal part to integers.
             // To circumvent this behavior, integers are converted to floats when denormalizing JSON based formats and when
             // a float is expected.
-            if (Type::BUILTIN_TYPE_FLOAT === $builtinType && \is_int($data) && str_contains($format, JsonEncoder::FORMAT)) {
+            if (Type::BUILTIN_TYPE_FLOAT === $builtinType && \is_int($data) && false !== strpos($format, JsonEncoder::FORMAT)) {
                 return (float) $data;
             }
 

--- a/Normalizer/GetSetMethodNormalizer.php
+++ b/Normalizer/GetSetMethodNormalizer.php
@@ -86,9 +86,9 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         return
             !$method->isStatic() &&
             (
-                ((str_starts_with($method->name, 'get') && 3 < $methodLength) ||
-                (str_starts_with($method->name, 'is') && 2 < $methodLength) ||
-                (str_starts_with($method->name, 'has') && 3 < $methodLength)) &&
+                ((0 === strpos($method->name, 'get') && 3 < $methodLength) ||
+                (0 === strpos($method->name, 'is') && 2 < $methodLength) ||
+                (0 === strpos($method->name, 'has') && 3 < $methodLength)) &&
                 0 === $method->getNumberOfRequiredParameters()
             )
         ;
@@ -108,7 +108,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
                 continue;
             }
 
-            $attributeName = lcfirst(substr($method->name, str_starts_with($method->name, 'is') ? 2 : 3));
+            $attributeName = lcfirst(substr($method->name, 0 === strpos($method->name, 'is') ? 2 : 3));
 
             if ($this->isAllowedAttribute($object, $attributeName, $format, $context)) {
                 $attributes[] = $attributeName;

--- a/Normalizer/ObjectNormalizer.php
+++ b/Normalizer/ObjectNormalizer.php
@@ -82,14 +82,14 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             $name = $reflMethod->name;
             $attributeName = null;
 
-            if (str_starts_with($name, 'get') || str_starts_with($name, 'has')) {
+            if (0 === strpos($name, 'get') || 0 === strpos($name, 'has')) {
                 // getters and hassers
                 $attributeName = substr($name, 3);
 
                 if (!$reflClass->hasProperty($attributeName)) {
                     $attributeName = lcfirst($attributeName);
                 }
-            } elseif (str_starts_with($name, 'is')) {
+            } elseif (0 === strpos($name, 'is')) {
                 // issers
                 $attributeName = substr($name, 2);
 


### PR DESCRIPTION
`str_contains` and `str_starts_with` are only available from PHP 8.0, since this version requires `>=7.1.3` this function will fail on older PHP versions.

So we need to revert this to the `strpos()` method.

I see also up to version `5.4` this method is used. But version `5.4` needs also PHP `>=7.2.5` so there it will break too. What is the best practice to update this? Because i don't want to change all tags and versions.

Also another side note, in PHP 8.0 `str_contains()` does allow `null` but in PHP 8.1 `null` isn't allowed so the check `str_contains` will fail because `$format` can be `null`