### PR TITLE
Add to context currentClass and attribute name for an Object

### DIFF
--- a/Normalizer/AbstractObjectNormalizer.php
+++ b/Normalizer/AbstractObjectNormalizer.php
@@ -562,7 +562,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
                     $childContext = $this->createChildContext($context, $attribute, $format);
                     if ($this->serializer->supportsDenormalization($data, $class, $format, $childContext)) {
-                        return $this->serializer->denormalize($data, $class, $format, $childContext);
+                        return $this->serializer->denormalize($data, $class, $format, array_merge($childContext, ['current_attribute' => $attribute, 'current_class' => $currentClass]));
                     }
                 }
 


### PR DESCRIPTION
Useful for solving everything related to the current class and the attribute such as the information in the DocBlock, and in particular, on the generic types powered by PhpStan for an attribute which required more advanced information on its typing (and according to the data received).

For instance :

A ClassFoo is triggered for denormalization --> The type of the attribute to denormalize is `mixed` BUT with a `DocBlock` node like `@var GenericTypeA<GenericTypeB<Union|Type|null>>`. Thus, to resolve the type used at the end of the chain, having the current attribute and the current class helps a lot, especially with another extractor or a piece of homemade code, it is really useful to retrieve information about the class by reflexivity for example through the combination `currentClassName:currentAttributeName`